### PR TITLE
Fix build and run

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   GtkBuilder XML format is quite verbose, and many app developers don't like using WYSIWYG editors for creating UIs. Blueprint files are intended to be a concise, easy-to-read format that makes it easier to create and edit GTK UIs.
   Internally, it compiles to GtkBuilder XML as part of an app's build system. It adds no new features, just makes the features that exist more accessible.
   Another goal is to have excellent developer tooling--including a language server--so that less knowledge of the format is required. Hopefully this will increase adoption of cool advanced features like GtkExpression.
-license: GPL-2.0 or LGPL-2.1-or-later
+license: GPL-2.0 OR LGPL-2.1-or-later
 grade: stable
 confinement: classic
 platforms:
@@ -19,43 +19,6 @@ platforms:
   armhf:
 
 parts:
-  # launcher:
-  #   plugin: dump
-  #   source: .
-  #   override-build: |
-  #     cp launcher $CRAFT_PART_INSTALL/
-
-  # ninja:
-  #   plugin: nil
-  #   source: https://github.com/ninja-build/ninja.git
-  #   source-tag: "v1.12.0"
-  #   source-depth: 1
-  #   override-build: |
-  #     rm -rf build
-  #     rm -f ninja
-  #     rm -f ninja_bootstrap
-  #     sed -i 's_^#!/usr/bin/env python$_#!/usr/bin/env python3_g' configure.py
-  #     ./configure.py --bootstrap
-  #     mv ninja ninja_bootstrap
-  #     rm -rf build
-  #     ./ninja_bootstrap
-  #     rm -f ninja_bootstrap
-  #     mkdir -p $CRAFT_PART_INSTALL/usr/bin
-  #     mv ninja $CRAFT_PART_INSTALL/usr/bin/
-  #   build-packages:
-  #     - python3
-  #   override-prime: ""
-
-  # meson-deps:
-  #   after: [ninja]
-  #   plugin: python
-  #   source: https://github.com/mesonbuild/meson.git
-  #   source-tag: "1.4.0"
-  #   source-depth: 1
-  #   build-packages:
-  #     - python3-pip
-  #   override-prime: ""
-
   blueprint-compiler:
     plugin: meson
     source: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
@@ -77,5 +40,5 @@ apps:
   blueprint-compiler:
     command: usr/bin/blueprint-compiler
     environment:
-      GI_TYPELIB_PATH: /snap/gnome-46-2404-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET/girepository-1.0:/snap/gnome-46-2404-sdk/current/usr/lib/girepository-1.0:/usr/lib/$CRAFT_ARCH_TRIPLET/girepository-1.0:/usr/lib/girepository-1.0:$GI_TYPELIB_PATH
-      LD_LIBRARY_PATH: /snap/gnome-46-2404-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET:/snap/gnome-46-2404-sdk/current/usr/lib:/usr/lib/$CRAFT_ARCH_TRIPLET:/usr/lib:$LD_LIBRARY_PATH
+      GI_TYPELIB_PATH: /snap/gnome-46-2404-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:/snap/gnome-46-2404-sdk/current/usr/lib/girepository-1.0:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:/usr/lib/girepository-1.0:$GI_TYPELIB_PATH
+      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH


### PR DESCRIPTION
The current snapcraft.yaml file doesn't build because the `license` field has an "or" statement in lowercase, when the specification says that it must be in uppercase.

Also, the built snap returns a core dump because it tries to use the libraries in the gnome-46-2404-sdk instead of its own ones. This is fixed by removing the LD_LIBRARY_PATH definition in the `environment` statement. Once this is fixed, it still is required to add the snap to the PYTHONPATH.

Finally, snapcraft shown several warnings due to still using CRAFT_ARCH_TRIPLET without the _BUILD_FOR.

This PR fixes all this, and also removes all the unneeded, commented parts in the snapcraft.yaml file.

Fix #3