### PR TITLE
Allow building for riscv64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ platforms:
   amd64:
   arm64:
   armhf:
+  riscv64:
 
 parts:
   blueprint-compiler:


### PR DESCRIPTION
Fixes #6

Allow building for riscv64

Tests show that the build works without errors (except for #5)